### PR TITLE
Updated to be compatible with numpy>=2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ from numpyencoder import NumpyEncoder
 numpy_data = np.array([0, 1, 2, 3])
 
 with open(json_file, 'w') as file:
-    json.dump(numpy_data, file, indent=4, sort_keys=True,
-              separators=(', ', ': '), ensure_ascii=False,
-              cls=NumpyEncoder)
+    json.dump(
+        numpy_data,
+        file,
+        indent=4,
+        sort_keys=True,
+        separators=(', ', ': '),
+        ensure_ascii=False,
+        cls=NumpyEncoder
+    )
 ```

--- a/numpyencoder/numpyencoder.py
+++ b/numpyencoder/numpyencoder.py
@@ -3,31 +3,45 @@ import numpy as np
 
 
 class NumpyEncoder(json.JSONEncoder):
-    """ Custom encoder for numpy data types """
+    """Custom encoder for numpy data types"""
+
     def default(self, obj):
-        if isinstance(obj, (np.int_, np.intc, np.intp, np.int8,
-                            np.int16, np.int32, np.int64, np.uint8,
-                            np.uint16, np.uint32, np.uint64)):
+        if isinstance(
+            obj,
+            (
+                np.int_,
+                np.intc,
+                np.intp,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+            ),
+        ):
 
             return int(obj)
 
-        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
-        
+
         elif isinstance(obj, (np.complex_, np.complex64, np.complex128)):
-            return {'real': obj.real, 'imag': obj.imag}
-        
+            return {"real": obj.real, "imag": obj.imag}
+
         elif isinstance(obj, (np.ndarray,)):
             return obj.tolist()
-    
+
         elif isinstance(obj, (np.bool_)):
             return bool(obj)
 
-        elif isinstance(obj, (np.void)): 
+        elif isinstance(obj, (np.void)):
             return None
 
         return json.JSONEncoder.default(self, obj)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     numpy_encoder = NumpyEncoder()

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,25 @@
 from setuptools import setup
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='numpyencoder',
-    version='0.2.0',
-    author='Hunter M. Allen',
-    author_email='allenhm@gmail.com',
-    license='MIT',
-    #packages=find_packages(),
-    packages=['numpyencoder'],
-    install_requires=['numpy>=1.14.3'],
-    description='Python JSON encoder for handling Numpy data types.',
+    name="numpyencoder",
+    version="0.2.0",
+    author="Hunter M. Allen",
+    author_email="allenhm@gmail.com",
+    license="MIT",
+    # packages=find_packages(),
+    packages=["numpyencoder"],
+    install_requires=["numpy>=1.14.3"],
+    description="Python JSON encoder for handling Numpy data types.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/hmallen/numpyencoder',
-    keywords=['numpy', 'json', 'encoder'],
+    long_description_content_type="text/markdown",
+    url="https://github.com/hmallen/numpyencoder",
+    keywords=["numpy", "json", "encoder"],
     classifiers=(
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
     ),
 )

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -6,8 +6,12 @@ def test_array_of_int():
     numpy_data = np.array([np.int64(0), np.int32(1), 2, 3])
     baseline_data = [0, 1, 2, 3]
 
-    j_np = json.dumps(numpy_data, sort_keys=True,
-                      separators=(', ', ': '), ensure_ascii=False,
-                      cls=NumpyEncoder)
+    j_np = json.dumps(
+        numpy_data,
+        sort_keys=True,
+        separators=(", ", ": "),
+        ensure_ascii=False,
+        cls=NumpyEncoder,
+    )
 
     assert json.dumps(baseline_data, sort_keys=True) == j_np


### PR DESCRIPTION
Removed usage of  (deprecated) `np.float_` to make compatible with `numpy` versions >= 2.0.0 + linted using `pylint`.