### PR TITLE
feature: handle Numpy type deprecation & backwards compatibility

### DIFF
--- a/numpyencoder/numpyencoder.py
+++ b/numpyencoder/numpyencoder.py
@@ -1,5 +1,26 @@
+import warnings
 import json
 import numpy as np
+
+
+# Both np.float_ and np.complex_ were deprecated in Numpy 2.0.0
+if np.__version__ < "2.0.0":
+    TYPES = {
+        "float": (np.float_, np.float16, np.float32, np.float64),
+        "complex": (np.complex_, np.complex64, np.complex128),
+    }
+    warnings.warn(
+        f"You are using an old version of Numpy ({np.__version__}), "
+        "support for 'np.float_' and 'np.complex_' were deprecated "
+        "in Numpy 2.0.0. If you use these datatypes in your code "
+        "please consider updating them.",
+        category=DeprecationWarning,
+    )
+else:
+    TYPES = {
+        "float": (np.float16, np.float32, np.float64),
+        "complex": (np.complex64, np.complex128),
+    }
 
 
 class NumpyEncoder(json.JSONEncoder):
@@ -22,13 +43,12 @@ class NumpyEncoder(json.JSONEncoder):
                 np.uint64,
             ),
         ):
-
             return int(obj)
 
-        elif isinstance(obj, (np.float16, np.float32, np.float64)):
+        elif isinstance(obj, TYPES["float"]):
             return float(obj)
 
-        elif isinstance(obj, (np.complex_, np.complex64, np.complex128)):
+        elif isinstance(obj, TYPES["complex"]):
             return {"real": obj.real, "imag": obj.imag}
 
         elif isinstance(obj, (np.ndarray,)):

--- a/numpyencoder/numpyencoder.py
+++ b/numpyencoder/numpyencoder.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 # Both np.float_ and np.complex_ were deprecated in Numpy 2.0.0
-if np.__version__ < "2.0.0":
+if parse_version(np.__version__) < parse_version("2.0.0"):
     TYPES = {
         "float": (np.float_, np.float16, np.float32, np.float64),
         "complex": (np.complex_, np.complex64, np.complex128),

--- a/numpyencoder/numpyencoder.py
+++ b/numpyencoder/numpyencoder.py
@@ -1,4 +1,5 @@
 import warnings
+from packaging.version import parse as parse_version
 import json
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="numpyencoder",
-    version="0.3.1",
+    version="0.3.2",
     author="Hunter M. Allen",
     author_email="allenhm@gmail.com",
     license="MIT",


### PR DESCRIPTION
Closes #7

Detects Numpy version on the fly and sets the types for `float` and `complex` conditional on whether `np.__version__ < "2.0.0"`.

Includes a warning advising users to consider updating them if using an old version of Numpy.

No idea if this is a sensible way of approaching such issues so happy to be advised/guided on better ways of handling such issues.