### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.2] - 2025-07-14
+### Added
+- Support for Numpy 2.x deprecations. Complex and float types are
+  detected based on the installed Numpy version.
+- Explicit dependency on the `packaging` module.
+

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ with open(json_file, 'w') as file:
         cls=NumpyEncoder
     )
 ```
+
+## Installation
+
+```
+pip install numpyencoder==0.3.2
+```
+

--- a/numpyencoder/__init__.py
+++ b/numpyencoder/__init__.py
@@ -1,1 +1,11 @@
+"""Top level package for ``numpyencoder``.
+
+Exposes :class:`~numpyencoder.numpyencoder.NumpyEncoder` for convenient
+imports and defines the package ``__version__``.
+"""
+
 from .numpyencoder import NumpyEncoder
+
+__version__ = "0.3.2"
+
+__all__ = ["NumpyEncoder", "__version__"]


### PR DESCRIPTION
## Summary
- expose package version from `numpyencoder.__init__`
- document installation instructions
- add changelog for v0.3.2
- export `__version__` from the public API list

## Testing
- `pip install .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874ba13cbf48326a36717164314b928